### PR TITLE
Update slider_index.liquid

### DIFF
--- a/template_min_config/snippets/slider_index.liquid
+++ b/template_min_config/snippets/slider_index.liquid
@@ -33,7 +33,7 @@
         {% capture is_show %}index_slider_{{ i }}-show{% endcapture %}
         {% capture image %}index_slider_{{ i }}-loaded.jpg{% endcapture %}
         {% capture link %}index_slider_{{ i }}-link{% endcapture %}
-        {% capture title %}index_slider_{{ i }}-title{% endcapture %}
+        {% capture slidetitle %}index_slider_{{ i }}-title{% endcapture %}
 
         {% comment %}
           генерим верстку


### PR DESCRIPTION
Переменная {{ title }} для слайдера, перезаписывает глобальную {{ title }} для вывода мета тайтла страницы. У меня появлялся тайтл "index_slider_5-title", я поменял на slidetitle, принципиально это или нет, но слайдер продолжает работать.
